### PR TITLE
Use integer division consistently in Python 2 & 3

### DIFF
--- a/Lib/spharm.py
+++ b/Lib/spharm.py
@@ -822,8 +822,8 @@ prevent deletion of read-only instance variables.
 
         if len(vrtspec.shape) == 1:
             nt = 1
-            vrtspec = numpy.reshape(vrtspec, ((ntrunc+1)*(ntrunc+2)/2,1))
-            divspec = numpy.reshape(divspec, ((ntrunc+1)*(ntrunc+2)/2,1))
+            vrtspec = numpy.reshape(vrtspec, ((ntrunc+1)*(ntrunc+2)//2,1))
+            divspec = numpy.reshape(divspec, ((ntrunc+1)*(ntrunc+2)//2,1))
         else:
             nt = vrtspec.shape[1]
 
@@ -875,7 +875,7 @@ prevent deletion of read-only instance variables.
 
         if len(chispec.shape) == 1:
             nt = 1
-            chispec = numpy.reshape(chispec, ((ntrunc+1)*(ntrunc+2)/2,1))
+            chispec = numpy.reshape(chispec, ((ntrunc+1)*(ntrunc+2)//2,1))
         else:
             nt = chispec.shape[1]
 


### PR DESCRIPTION
Replace `/` with `//` where integer division was intended. This forces the result to be an integer, as intended. This matters for later versions of numpy that disallow the use of floats when reshaping (even if they have integer value).