### PR TITLE
Expand package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Built object files
+src/*.o
+
+# Python build system intermediate files
+/build/
+/pyspharm.dist-info/
+/pyspharm.egg-info/
+
+# Source and binary distributions from setuptools
+/dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
+[metadata]
+classifiers=
+    Topic :: Scientific/Engineering :: Atmospheric Science
+license_files=
+    README
+    LICENSE.spherepack
+
 [options]
 install_requires=numpy
 setup_requires=numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options]
+install_requires=numpy
+setup_requires=numpy


### PR DESCRIPTION
Use recent mechanisms to declare NumPy a build-time dependency, note that it's also required at run-time, and add some more metadata I could guess from the documentation, and try to declutter `git status` reports of work that could be added to the repository.