### PR TITLE
fix compiler errors on pip install on Rocky 9

### DIFF
--- a/src/alf.f
+++ b/src/alf.f
@@ -263,6 +263,7 @@ c                        notes by paul n. swarztrauber)
 c
       subroutine lfim (init,theta,l,n,nm,pb,id,wlfim)
       dimension       pb(1)        ,wlfim(1)
+      dimension theta(l)
 c
 c     total length of wlfim is 4*l*(nm+1)
 c
@@ -276,7 +277,7 @@ c
       end
       subroutine lfim1(init,theta,l,n,nm,id,p3,phz,ph1,p1,p2,cp)
       dimension       p1(l,1)    ,p2(l,1)    ,p3(id,1)   ,phz(l,1)   ,
-     1                ph1(l,1)   ,cp(1)      ,theta(1)
+     1                ph1(l,1)   ,cp(1)      ,theta(l)
       nmp1 = nm+1
       if(init .ne. 0) go to 5
       ssqrt2 = 1./sqrt(2.)
@@ -455,6 +456,7 @@ c                        notes by paul n. swarztrauber)
 c
       subroutine lfin (init,theta,l,m,nm,pb,id,wlfin)
       dimension       pb(1)        ,wlfin(1)
+      dimension theta(l)
 c
 c     total length of wlfin is 4*l*(nm+1)
 c
@@ -468,7 +470,7 @@ c
       end
       subroutine lfin1(init,theta,l,m,nm,id,p3,phz,ph1,p1,p2,cp)
       dimension       p1(l,1)    ,p2(l,1)    ,p3(id,1)   ,phz(l,1)   ,
-     1                ph1(l,1)   ,cp(1)      ,theta(1)
+     1                ph1(l,1)   ,cp(1)      ,theta(l)
       nmp1 = nm+1
       if(init .ne. 0) go to 5
       ssqrt2 = 1./sqrt(2.)


### PR DESCRIPTION
The version currently on pypi fails during `pip install` on a Rocky 9 machine with a couple of errors while compiling `alf.f`:
```
      Error: Rank mismatch in argument 'theta' at (1) (rank-1 and scalar)
      src/alf.f:465:22:
      
        465 |       call lfin1(init,theta,l,m,nm,id,pb,wlfin,wlfin(iw1),
            |                      1
      Error: Rank mismatch in argument 'theta' at (1) (rank-1 and scalar)
```
On earlier versions of gfortran, this error was a warning, but on 13.2.0 it is an error unless `-fallow-argument-mismatch` is used.

This patch includes the bare minimum change needed to get past that error, by declaring `theta` as an array in the caller (based on what the comment lines say) - and it seems that the array length in the called subroutine should also be `l` rather than `1`.

I am not attempting to make any other changes, although I note that there are a lot of warnings from the compiler regarding that source file, including Fortran 2018 deleted language features.

For the time being we will install from this fork when installing Jaspy (a data analysis conda environment for the JASMIN service) - per https://github.com/cedadev/ceda-jaspy-envs/issues/139 - but if you could please say when the PR is merged (or otherwise fixed) and then published to PyPI, we can then go back to installing from PyPI.  Or we can install from a github tag, but currently it seems that releases are not tagged.

Thanks.