### PR TITLE
BUG: Fix meson build to include python files and use pyf for f2py

### DIFF
--- a/examples/2levelturb.py
+++ b/examples/2levelturb.py
@@ -11,7 +11,7 @@ from mpl_toolkits.basemap import Basemap, addcyclic
 # set model parameters.
 nlons = 128  # number of longitudes
 ntrunc = 42  # spectral truncation (for alias-free computations)
-nlats = (nlons/2)+1 # for regular grid.
+nlats = (nlons//2)+1 # for regular grid.
 gridtype = 'regular'
 dt = 900 # time step in seconds
 tdiab = 12.*86400 # thermal relaxation time scale
@@ -61,8 +61,8 @@ m.drawmeridians(np.arange(-180,180,60),labels=[0,0,0,1],ax=ax2)
 m.drawparallels(np.arange(-60,91,30),labels=[1,0,0,0],ax=ax2)
 levs1 = np.arange(-1.6e-4,1.61e-4,2.e-5)
 levs2 = np.arange(-60,21,2)
-CS1=m.contourf(x,y,data1,levs1,cmap=plt.cm.spectral,extend='both',ax=ax1)
-CS2=m.contourf(x,y,data2,levs2,cmap=plt.cm.spectral,extend='both',ax=ax2)
+CS1=m.contourf(x,y,data1,levs1,cmap="Spectral",extend='both')  # ,ax=ax1)
+CS2=m.contourf(x,y,data2,levs2,cmap="Spectral",extend='both',ax=ax2)
 cb1 = m.colorbar(CS1,location='right',format='%3.1e',ax=ax1)
 cb2 = m.colorbar(CS2,location='right',format='%g',ax=ax2)
 t = 0.
@@ -79,9 +79,9 @@ def updatefig(*args):
     data2,lons1dx = addcyclic(model.theta,lons1d)
     # remove old contours, add new ones.
     for c in CS1.collections: c.remove()
-    CS1=m.contourf(x,y,data1,levs1,cmap=plt.cm.spectral,extend='both',ax=ax1)
+    CS1=m.contourf(x,y,data1,levs1,cmap="Spectral",extend='both',ax=ax1)
     for c in CS2.collections: c.remove()
-    CS2=m.contourf(x,y,data2,levs2,cmap=plt.cm.spectral,extend='both',ax=ax2)
+    CS2=m.contourf(x,y,data2,levs2,cmap="Spectral",extend='both',ax=ax2)
     # update titles.
     txt1.set_text('Upper Level Vorticity (T%s, hour %6.2f)' % (ntrunc,t/3600.))
     txt2.set_text('Temperature (T%s, hour %6.2f)' % (ntrunc,t/3600.))

--- a/examples/galewskyetal_testcase.py
+++ b/examples/galewskyetal_testcase.py
@@ -14,7 +14,7 @@ import time
 # grid, time step info
 nlons = 256  # number of longitudes
 ntrunc = 84 # spectral truncation (for alias-free computations)
-nlats = (nlons/2)+1 # for regular grid.
+nlats = (nlons//2)+1 # for regular grid.
 gridtype = 'regular'
 #nlats = nlons/2 # for gaussian grid.
 #gridtype = 'gaussian'
@@ -81,14 +81,15 @@ nnew = 0; nnow = 1; nold = 2
 
 # time loop.
 
-time1 = time.clock()
+time1 = time.process_time()
 for ncycle in range(itmax+1):
     t = ncycle*dt
 # get vort,u,v,phi on grid
     vrtg = x.spectogrd(vrtspec)
     ug,vg = x.getuv(vrtspec,divspec)
     phig = x.spectogrd(phispec)
-    print('t=%6.2f hours: min/max %6.2f, %6.2f' % (t/3600.,vg.min(), vg.max()))
+    if ncycle % 24 == 0:
+        print('t=%6.2f hours: min/max %6.2f, %6.2f' % (t/3600.,vg.min(), vg.max()))
 # compute tendencies.
     tmpg1 = ug*(vrtg+f); tmpg2 = vg*(vrtg+f)
     ddivdtspec[:,nnew], dvrtdtspec[:,nnew] = x.getvrtdivspec(tmpg1,tmpg2,ntrunc)
@@ -127,7 +128,7 @@ for ncycle in range(itmax+1):
     nsav1 = nnew; nsav2 = nnow
     nnew = nold; nnow = nsav1; nold = nsav2
 
-time2 = time.clock()
+time2 = time.process_time()
 print('CPU time = ',time2-time1)
 
 # make a orthographic plot of potential vorticity.
@@ -141,7 +142,7 @@ x,y = m(lons,lats)
 levs = np.arange(-0.2,1.801,0.1)
 m.drawmeridians(np.arange(-180,180,60))
 m.drawparallels(np.arange(-80,81,20))
-CS=m.contourf(x,y,pvg,levs,cmap=plt.cm.spectral,extend='both')
+CS=m.contourf(x,y,pvg,levs,cmap="Spectral",extend='both')
 m.colorbar()
 plt.title('PV (T%s with hyperdiffusion, hour %6.2f)' % (ntrunc,t/3600.))
 plt.show()

--- a/examples/geodesic.py
+++ b/examples/geodesic.py
@@ -12,7 +12,7 @@ map.drawmapboundary(fill_color='aqua')
 # draw lat/lon grid lines every 30 degrees.
 map.drawmeridians(np.arange(0,360,30))
 map.drawparallels(np.arange(-90,90,30))
-m = int(raw_input('input the number of points on the edge of each spherical geodesic triangle:'))
+m = int(input('input the number of points on the edge of each spherical geodesic triangle:'))
 # find the geodesic points.
 lats, lons = getgeodesicpts(m)
 x, y = map(lons, lats)

--- a/examples/spharmonic.py
+++ b/examples/spharmonic.py
@@ -11,8 +11,8 @@ map.drawmapboundary()
 # draw lat/lon grid lines every 30 degrees.
 map.drawmeridians(np.arange(0,360,30))
 map.drawparallels(np.arange(-90,90,30))
-min = int(raw_input('input degree (m) of legendre function to plot:'))
-nin = int(raw_input('input order  (n) of legendre function to plot:'))
+min = int(input('input degree (m) of legendre function to plot:'))
+nin = int(input('input order  (n) of legendre function to plot:'))
 nlons = 720; nlats = 361
 x = Spharmt(nlons,nlats,legfunc='computed')
 ntrunc = nlats-1
@@ -27,7 +27,7 @@ for m,n in zip(indxm,indxn):
         i = i + 1
 if nm < 0:
     raise ValueError('invalid m,n - must fit within triangular truncation at wavenumber '+repr(ntrunc))
-coeffs = np.zeros((ntrunc+1)*(ntrunc+2)/2,np.complex)
+coeffs = np.zeros((ntrunc+1)*(ntrunc+2)//2,np.complex128)
 coeffs[nm] = 1.
 spharmonic = x.spectogrd(coeffs)
 delta = 360./nlons

--- a/examples/twolayer.py
+++ b/examples/twolayer.py
@@ -158,12 +158,12 @@ if __name__ == "__main__":
     # grid, time step info
     nlons = 128  # number of longitudes
     ntrunc = 42 # spectral truncation (for alias-free computations)
-    nlats = (nlons/2)+1 # for regular grid.
+    nlats = (nlons//2)+1 # for regular grid.
     gridtype = 'regular'
     #nlats = nlons/2 # for gaussian grid.
     #gridtype = 'gaussian'
     dt = 900 # time step in seconds
-    itmax = 8*(86400/dt) # integration length in days
+    itmax = 8*(86400//dt) # integration length in days
     umax = 50. # jet speed
     jetexp = 10 # parameter controlling jet width
 
@@ -192,14 +192,14 @@ if __name__ == "__main__":
         raise ValueError('negative layer thickness! adjust jet parameters')
 
     # time loop.
-    time1 = time.clock()
+    time1 = time.process_time()
     for ncycle in range(itmax+1):
         t = ncycle*model.dt
         vrtspec, divspec, lyrthkspec = model.rk4step(vrtspec, divspec, lyrthkspec)
         pvg = (0.5*model.zmid/model.omega)*(model.vrt + model.f)/model.lyrthk
         print('t=%6.2f hours: v min/max %6.2f, %6.2f pv min/max %6.2f, %6.2f'%\
         (t/3600.,model.v.min(), model.v.max(), pvg.min(), pvg.max()))
-    time2 = time.clock()
+    time2 = time.process_time()
     print('CPU time = ',time2-time1)
 
     # make a plot of upper layer thickness
@@ -212,7 +212,7 @@ if __name__ == "__main__":
     x,y = m(lons,lats)
     m.drawmeridians(np.arange(-180,180,60))
     m.drawparallels(np.arange(-80,81,20))
-    CS=m.contourf(x,y,lyrthk,30,cmap=plt.cm.spectral,extend='both')
+    CS=m.contourf(x,y,lyrthk,30,cmap="Spectral",extend='both')
     m.colorbar()
     plt.title('Upper-Layer Thickness (T%s, hour %6.2f)' % (ntrunc,t/3600.))
     plt.show()

--- a/examples/twolevel.py
+++ b/examples/twolevel.py
@@ -169,12 +169,12 @@ if __name__ == "__main__":
     # grid, time step info
     nlons = 128  # number of longitudes
     ntrunc = 42 # spectral truncation (for alias-free computations)
-    nlats = (nlons/2)+1 # for regular grid.
+    nlats = (nlons//2)+1 # for regular grid.
     gridtype = 'regular'
     #nlats = nlons/2 # for gaussian grid.
     #gridtype = 'gaussian'
     dt = 1800 # time step in seconds
-    itmax = int(5*(86400/dt)) # integration length in days
+    itmax = int(5*(86400//dt)) # integration length in days
     umax = 50. # jet speed
     jetexp = 6 # parameter controlling jet width
 
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     x,y = m(lons,lats)
     m.drawmeridians(np.arange(-180,180,60))
     m.drawparallels(np.arange(-80,81,20))
-    CS=m.contourf(x,y,thetag,30,cmap=plt.cm.spectral,extend='both')
+    CS=m.contourf(x,y,thetag,30,cmap="Spectral",extend='both')
     m.colorbar()
     plt.title('Temperature (T%s, hour %6.2f)' % (ntrunc,t/3600.))
     plt.show()

--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,7 @@ incdir_f2py = run_command(py,
 ).stdout().strip()
 
 spherepack_source = custom_target('_spherepackmodule.c',
-    input: [
-        'src/_spherepack.pyf'],
+    input: ['src/_spherepack.pyf'],
     output: ['_spherepackmodule.c', '_spherepack-f2pywrappers.f'],
     command: [py, '-m', 'numpy.f2py', '--lower', '@INPUT@']
 )

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,13 @@ py_mod = import('python')
 py = py_mod.find_installation(pure: false)
 py_dep = py.dependency()
 
+py.install_sources([
+		'Lib/__init__.py',
+		'Lib/spharm.py',
+	],
+	subdir: 'spharm'
+)
+
 incdir_numpy = run_command(py,
   ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
   check : true

--- a/meson.build
+++ b/meson.build
@@ -32,40 +32,9 @@ incdir_f2py = run_command(py,
 
 spherepack_source = custom_target('_spherepackmodule.c',
     input: [
-        'src/_spherepack.pyf',
-	'src/getlegfunc.f',
-	'src/specintrp.f',
-	'src/onedtotwod.f',
-	'src/onedtotwod_vrtdiv.f',
-	'src/twodtooned.f',
-	'src/twodtooned_vrtdiv.f',
-	'src/multsmoothfact.f',
-	'src/lap.f',
-	'src/invlap.f',
-        # SPHEREPACK sources
-        'src/gaqd.f',
-	'src/shses.f',
-	'src/shaes.f',
-	'src/vhaes.f',
-	'src/vhses.f',
-	'src/shsgs.f',
-	'src/shags.f',
-	'src/vhags.f',
-	'src/vhsgs.f',
-	'src/sphcom.f',
-	'src/hrfft.f',
-	'src/shaec.f',
-	'src/shagc.f',
-	'src/shsec.f',
-	'src/shsgc.f',
-	'src/vhaec.f',
-	'src/vhagc.f',
-	'src/vhsec.f',
-	'src/vhsgc.f',
-	'src/ihgeod.f',
-	'src/alf.f'],
+        'src/_spherepack.pyf'],
     output: ['_spherepackmodule.c', '_spherepack-f2pywrappers.f'],
-    command: [py, '-m', 'numpy.f2py', '@INPUT@', '-m', '_spherepack', '--lower']
+    command: [py, '-m', 'numpy.f2py', '--lower', '@INPUT@']
 )
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)


### PR DESCRIPTION
Should fix #15 and maybe also  #6

Add @DominikStiller's patch to include the python files in the wheel, then call f2py using only the pyf file so it generates the proper wrappers.

Finally, update the examples for python 3 and recent matplotlib.

Follow-up to #14 to not be broken, checked against [example scripts in this repository](https://github.com/jswhit/pyspharm/tree/master/examples) and [in the windspharm repository](https://github.com/ajdawson/windspharm/tree/master/examples).