### PR TITLE
ENH: Replace reshape(*shape, 1) with expand_dims(ndim)

### DIFF
--- a/Lib/spharm.py
+++ b/Lib/spharm.py
@@ -401,7 +401,7 @@ prevent deletion of read-only instance variables.
 
         if len(datagrid.shape) == 2:
             nt = 1
-            datagrid = numpy.reshape(datagrid, (nlat,nlon,1))
+            datagrid = numpy.expand_dims(datagrid, 2)
         else:
             nt = datagrid.shape[2]
 
@@ -484,7 +484,7 @@ prevent deletion of read-only instance variables.
 
         if len(dataspec.shape) == 1:
             nt = 1
-            dataspec = numpy.reshape(dataspec, (dataspec.shape[0],1))
+            dataspec = numpy.expand_dims(dataspec, 1)
         else:
             nt = dataspec.shape[1]
 
@@ -602,8 +602,8 @@ prevent deletion of read-only instance variables.
 
         if len(shapeu) == 2:
             nt = 1
-            w = numpy.reshape(ugrid, (nlat,nlon,1))
-            v = -numpy.reshape(vgrid, (nlat,nlon,1))
+            w = numpy.expand_dims(ugrid, 2)
+            v = -numpy.expand_dims(vgrid, 2)
         else:
             nt = shapeu[2]
             w = ugrid
@@ -710,8 +710,8 @@ prevent deletion of read-only instance variables.
 
         if len(vrtspec.shape) == 1:
             nt = 1
-            vrtspec = numpy.reshape(vrtspec, (vrtspec.shape[0],1))
-            divspec = numpy.reshape(divspec, (divspec.shape[0],1))
+            vrtspec = numpy.expand_dims(vrtspec, 1)
+            divspec = numpy.expand_dims(divspec, 1)
         else:
             nt = vrtspec.shape[1]
 
@@ -822,8 +822,8 @@ prevent deletion of read-only instance variables.
 
         if len(vrtspec.shape) == 1:
             nt = 1
-            vrtspec = numpy.reshape(vrtspec, ((ntrunc+1)*(ntrunc+2)//2,1))
-            divspec = numpy.reshape(divspec, ((ntrunc+1)*(ntrunc+2)//2,1))
+            vrtspec = numpy.expand_dims(vrtspec, 1)
+            divspec = numpy.expand_dims(divspec, 1)
         else:
             nt = vrtspec.shape[1]
 
@@ -875,7 +875,7 @@ prevent deletion of read-only instance variables.
 
         if len(chispec.shape) == 1:
             nt = 1
-            chispec = numpy.reshape(chispec, ((ntrunc+1)*(ntrunc+2)//2,1))
+            chispec = numpy.expand_dims(chispec, 1)
         else:
             nt = chispec.shape[1]
 

--- a/tests/test_array_api.py
+++ b/tests/test_array_api.py
@@ -1,0 +1,26 @@
+import pytest
+
+import spharm
+
+array_api = pytest.importorskip("numpy.array_api")
+
+test_data = [array_api.ones((32, 64), dtype=array_api.float32)]
+
+try:
+    import xarray as xr
+except ImportError:
+    pass
+else:
+    test_data.append(xr.DataArray(test_data[0], dims=["lat", "lon"]))
+
+transform = spharm.Spharmt(64, 32)
+
+
+@pytest.mark.parametrize("data", test_data)
+def test_grdtospec(data):
+    result = transform.grdtospec(data, 21)
+
+
+@pytest.mark.parametrize("data", test_data)
+def test_regrid(data):
+    result = spharm.regrid(transform, transform, data, 21)


### PR DESCRIPTION
This might enable use of this library on a fair number of Array API libraries.

Closes #9 (allows call to succeed; does not return an XArray object, since it doesn't have the metadata).  Might also speed things up a bit, but probably not enough to matter.