### PR TITLE
TST: Add tests of package behavior using PyTest

### DIFF
--- a/Lib/spharm.py
+++ b/Lib/spharm.py
@@ -170,6 +170,9 @@ prevent deletion of read-only instance variables.
         else:
             del self.__dict__[key]
 
+    def __repr__(self):
+        return "Spharmt({:d}, {:d}, {:e}, {:s}, {:s})".format(self.nlon, self.nlat, self.rsphere, self.gridtype, self.legfunc)
+
     def __init__(self, nlon, nlat, rsphere=6.3712e6, gridtype='regular', legfunc='stored'):
         """
  create a Spharmt class instance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [ "numpy" ]
 Homepage = "http://github.com/jswhit/pyspharm"
 Repository = "https://github.com/jswhit/pyspharm"
 
+[project.optional-dependencies]
+tests = ["pytest"]
+examples = ["basemap", "matplotlib"]
+
 [tool.setuptools]
 packages = [ "spharm" ]
 package-dir = { spharm = "Lib" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Homepage = "http://github.com/jswhit/pyspharm"
 Repository = "https://github.com/jswhit/pyspharm"
 
 [project.optional-dependencies]
-tests = ["pytest"]
+tests = ["pytest", "hypothesis[numpy]"]
 examples = ["basemap", "matplotlib"]
 
 [tool.setuptools]

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,118 @@
+import itertools
+
+import numpy as np
+import pytest
+
+import spharm
+
+hypothesis = pytest.importorskip("hypothesis")
+st = pytest.importorskip("hypothesis.strategies")
+hy_np = pytest.importorskip("hypothesis.extra.numpy")
+
+
+NTRUNC = [21, 42]
+NLATS = 64
+
+MAX_MAGNITUDE = np.float32(1e20)
+
+
+@pytest.fixture(
+    params=itertools.product(["regular"], ["stored"])  # "gaussian",  # "computed",
+)
+def spharmt(request):
+    """Create a (collection of) Spharmt instances for a test."""
+    nlon = NLATS * 2
+    transform = spharm.Spharmt(
+        nlon, NLATS, gridtype=request.param[0], legfunc=request.param[1]
+    )
+    return transform
+
+
+@pytest.mark.parametrize("ntrunc", NTRUNC)
+class TestSpharmt:
+
+    @hypothesis.given(
+        hy_np.arrays(
+            np.dtype("f4"),
+            (NLATS, NLATS * 2),
+            elements=hy_np.from_dtype(
+                np.dtype("f4"),
+                allow_infinity=False,
+                allow_nan=False,
+                allow_subnormal=False,
+                max_value=MAX_MAGNITUDE,
+                min_value=-MAX_MAGNITUDE,
+            ),
+        )
+    )
+    @hypothesis.settings(
+        suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture]
+    )
+    def test_roundtrip_spectral_grid(self, spharmt, ntrunc, test_data):
+        coeffs = spharmt.grdtospec(test_data, ntrunc)
+        smoothed_test_data = spharmt.spectogrd(coeffs)
+        recalculated_coeffs = spharmt.grdtospec(smoothed_test_data, ntrunc)
+        atol = 1e-6 * test_data.size * np.abs(test_data).max()
+        assert recalculated_coeffs == pytest.approx(coeffs, abs=atol, rel=1e-5)
+        recalculated_test_data = spharmt.spectogrd(recalculated_coeffs)
+        assert recalculated_test_data == pytest.approx(
+            smoothed_test_data, abs=atol, rel=1e-5
+        )
+
+    @hypothesis.given(
+        *(
+            2
+            * (
+                hy_np.arrays(
+                    np.dtype("f4"),
+                    (NLATS, NLATS * 2),
+                    elements=hy_np.from_dtype(
+                        np.dtype("f4"),
+                        allow_infinity=False,
+                        allow_nan=False,
+                        allow_subnormal=False,
+                        max_value=MAX_MAGNITUDE,
+                        min_value=-MAX_MAGNITUDE,
+                    ),
+                ),
+            )
+        )
+    )
+    @hypothesis.settings(
+        suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture]
+    )
+    def test_roundtrip_winds(self, spharmt, ntrunc, test_u, test_v):
+        if ntrunc > spharmt.nlat / 2:
+            pytest.skip("ntrunc > nlat/2")
+        expected_vrt, expected_div = spharmt.getvrtdivspec(test_u, test_v, ntrunc)
+        test_u, test_v = spharmt.getuv(expected_vrt, expected_div)
+        actual_vrt, actual_div = spharmt.getvrtdivspec(test_u, test_v, ntrunc)
+        atol = 1e-6 * test_u.size * max(test_u.max(), test_v.max())
+        assert actual_vrt == pytest.approx(expected_vrt, abs=atol, rel=3e-6)
+        assert actual_div == pytest.approx(expected_div, abs=atol, rel=3e-6)
+
+
+@hypothesis.given(
+    hy_np.arrays(
+        np.dtype("f4"),
+        (NLATS, NLATS * 2),
+        elements=hy_np.from_dtype(
+            np.dtype("f4"),
+            allow_infinity=False,
+            allow_nan=False,
+            allow_subnormal=False,
+            max_value=MAX_MAGNITUDE,
+            min_value=-MAX_MAGNITUDE,
+        ),
+    )
+)
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture]
+)
+def test_roundtrip_regrid(spharmt, test_data):
+    transform = spharm.Spharmt(192, 96)
+    expected_data = spharm.regrid(spharmt, spharmt, test_data)
+    hires_data = spharm.regrid(spharmt, transform, expected_data)
+    recovered_data = spharm.regrid(transform, spharmt, hires_data)
+    atol = 1e-6 * test_data.size * np.abs(test_data).max()
+    assert recovered_data == pytest.approx(expected_data, abs=atol, rel=1e-6)

--- a/tests/test_spharm.py
+++ b/tests/test_spharm.py
@@ -1,0 +1,246 @@
+import itertools
+
+import numpy as np
+import pytest
+import spharm
+
+# T799 transforms result in nans
+# T382 on a 512x1024 grid seems to work fine
+NTRUNC = [21, 42, 63]  # , 85]
+NLATS = [32, 64, 96]  # , 128]
+
+
+@pytest.fixture(
+    params=itertools.product(["gaussian", "regular"], ["computed", "stored"], NLATS)
+)
+def spharmt(request):
+    nlat = request.param[2]
+    nlon = nlat * 2
+    transform = spharm.Spharmt(
+        nlon, nlat, gridtype=request.param[0], legfunc=request.param[1]
+    )
+    return transform
+
+
+@pytest.mark.parametrize("transform_multiple", [False, True])
+@pytest.mark.parametrize("ntrunc", NTRUNC)
+class TestSpharmt:
+    """Test the Spharmt class.
+
+    longitude 0-360
+    latitude 90 -- -90
+    """
+
+    def test_grdtospec(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        if transform_multiple:
+            shape = (spharmt.nlat, spharmt.nlon, 5)
+        else:
+            shape = (spharmt.nlat, spharmt.nlon)
+        test_data = np.ones(shape, dtype="f4")
+        coeffs = spharmt.grdtospec(test_data, ntrunc)
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        assert coeffs.shape[0] == ncoeffs
+        if transform_multiple:
+            assert coeffs.shape[1] == 5
+        assert np.all(np.isfinite(coeffs))
+        assert coeffs[0] == pytest.approx(np.sqrt(2))
+        assert coeffs[1:] == pytest.approx(0, abs=1e-6 * ncoeffs)
+
+    def test_spectogrd(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        if transform_multiple:
+            shape = (ncoeffs, 5)
+        else:
+            shape = (ncoeffs,)
+        test_data = np.ones(shape, dtype="c8")
+        grid = spharmt.spectogrd(test_data)
+        assert grid.shape[0] == spharmt.nlat
+        assert grid.shape[1] == spharmt.nlon
+        if transform_multiple:
+            assert grid.shape[2] == 5
+        assert np.all(np.isfinite(grid))
+
+    def test_roundtrip_spectral_grid(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        elif spharmt.gridtype == "regular" and ntrunc > 1 * (spharmt.nlat + 1) / 2:
+            pytest.skip("ntrunc larger than nlat on regular grid")
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        if transform_multiple:
+            shape = (ncoeffs, 5)
+        else:
+            shape = (ncoeffs,)
+        size = np.prod(shape)
+        test_data = np.arange(size, dtype="c8").reshape(shape)
+        grid = spharmt.spectogrd(test_data)
+        coeffs = spharmt.grdtospec(grid, ntrunc)
+        assert coeffs == pytest.approx(test_data, abs=1e-6 * size, rel=7e-6)
+
+    def test_getuv(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        shape = (ncoeffs,)
+        if transform_multiple:
+            shape = shape + (5,)
+        vrt = div = np.ones(shape, "c8")
+        ugrid_vgrid = spharmt.getuv(vrt, div)
+        for grid in ugrid_vgrid:
+            assert grid.shape[0] == spharmt.nlat
+            assert grid.shape[1] == spharmt.nlon
+            if transform_multiple:
+                assert grid.shape[2] == 5
+            assert np.all(np.isfinite(grid))
+
+    def test_getvrtdivspec(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        shape = (spharmt.nlat, spharmt.nlon)
+        if transform_multiple:
+            shape = shape + (5,)
+        ugrid = vgrid = np.ones(shape, dtype="f4")
+        vrt_div = spharmt.getvrtdivspec(ugrid, vgrid, ntrunc)
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        for coeffs in vrt_div:
+            assert coeffs.shape[0] == ncoeffs
+            if transform_multiple:
+                assert coeffs.shape[1] == 5
+            assert np.all(np.isfinite(coeffs))
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize("scenario", [1, 2, 3])
+    def test_roundtrip_winds(self, spharmt, transform_multiple, ntrunc, scenario):
+        if ntrunc > spharmt.nlat / 2:
+            pytest.skip("ntrunc larger than nlat")
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        shape = (ncoeffs,)
+        if transform_multiple:
+            shape = shape + (5,)
+        size = np.prod(shape)
+        test_coeffs = np.arange(size, dtype="c8").reshape(shape)
+        zero_coeffs = np.zeros_like(test_coeffs)
+        if scenario & 1:
+            div = test_coeffs
+        else:
+            div = zero_coeffs
+        if scenario & 2:
+            vrt = test_coeffs
+        else:
+            vrt = zero_coeffs
+        ugrid, vgrid = spharmt.getuv(vrt, div)
+        actual_vrt, actual_div = spharmt.getvrtdivspec(ugrid, vgrid, ntrunc)
+        # TODO: Test with original code and no slicing
+        assert actual_vrt[4:] == pytest.approx(vrt[4:], abs=1e-6 * size)
+        assert actual_div[4:] == pytest.approx(div[4:], abs=1e-6 * size)
+
+    def test_getgrad(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        shape = (ncoeffs,)
+        if transform_multiple:
+            shape = shape + (5,)
+        test_data = np.ones(shape, dtype="c8")
+        uchi_vchi = spharmt.getgrad(test_data)
+        for grid in uchi_vchi:
+            assert grid.shape[0] == spharmt.nlat
+            assert grid.shape[1] == spharmt.nlon
+            if transform_multiple:
+                assert grid.shape[2] == 5
+            assert grid == pytest.approx(0.0, abs=1e-6 * max(ncoeffs, np.prod(grid.shape[:2])))
+
+    def test_getpsichi(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        shape = (spharmt.nlat, spharmt.nlon)
+        if transform_multiple:
+            shape = shape + (5,)
+        test_data = np.ones(shape, dtype="f4")
+        psi_chi = spharmt.getpsichi(test_data, test_data, ntrunc)
+        ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+        for coeffs in psi_chi:
+            assert coeffs.shape[:len(shape)] == shape
+            if transform_multiple:
+                assert coeffs.shape[2] == 5
+            assert np.all(np.isfinite(coeffs))
+
+    def test_specsmooth(self, spharmt, transform_multiple, ntrunc):
+        if ntrunc > spharmt.nlat - 1:
+            pytest.skip("ntrunc larger than nlat")
+        shape = (spharmt.nlat, spharmt.nlon)
+        if transform_multiple:
+            shape = shape + (5,)
+        test_data = np.ones(shape, dtype="f4")
+        smoothing_coeffs = np.ones(shape[0], dtype="f4")
+        smoothed = spharmt.specsmooth(test_data, smoothing_coeffs)
+        assert np.squeeze(smoothed) == pytest.approx(test_data, abs=1e-6 * shape[0])
+
+
+@pytest.mark.parametrize("smooth", [None, True])
+def test_regrid(spharmt, smooth):
+    ntrunc = 25
+    sourcegrid = spharm.Spharmt(54, 27)
+    test_data = np.ones((27, 54), dtype="f4")
+    if smooth is not None:
+        smooth = np.ones(spharmt.nlat)
+    hires_data = spharm.regrid(sourcegrid, spharmt, test_data, ntrunc, smooth)
+    lowres_data = spharm.regrid(spharmt, sourcegrid, hires_data, ntrunc)
+    assert np.squeeze(lowres_data) == pytest.approx(test_data, abs=1e-6 * spharmt.nlat)
+
+
+@pytest.mark.parametrize("nlat", NLATS)
+def test_gaussian_lats_wts(nlat):
+    lats, weights = spharm.gaussian_lats_wts(nlat)
+    assert np.all(lats <= 90)
+    assert np.all(lats >= -90)
+    assert np.all(weights >= 0)
+    assert np.sum(weights) == pytest.approx(2)
+
+
+@pytest.mark.parametrize("ntrunc", NTRUNC)
+def test_getspecindx(ntrunc):
+    wavenumber, degree = spharm.getspecindx(ntrunc)
+    assert np.all(wavenumber <= ntrunc)
+    assert np.all(degree <= ntrunc)
+    assert np.all(wavenumber <= degree)
+    assert np.all(degree >= 0)
+    assert np.all(wavenumber >= 0)
+    assert wavenumber.shape[0] == (ntrunc + 1) * (ntrunc + 2) // 2
+
+
+@pytest.mark.parametrize("lat", np.linspace(-90, 90, 7))
+@pytest.mark.parametrize("ntrunc", NTRUNC)
+def test_legendre(lat, ntrunc):
+    pnm = spharm.legendre(lat, ntrunc)
+    ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+    assert pnm.shape[0] == ncoeffs
+    assert np.all(np.isfinite(pnm))
+
+
+@pytest.mark.parametrize("m", range(1, 20))
+def test_getgeodesicpts(m):
+    lats, lons = spharm.getgeodesicpts(m)
+    assert np.all(lats >= -90)
+    assert np.all(lats <= 90)
+    assert np.all(lons >= 0)
+    assert np.all(lons <= 360)
+    npoints = 10 * (m - 1) ** 2 + 2
+    assert lats.shape[0] == npoints
+    # Only other test I can think of involves breaking out the
+    # heaviside formula and checking each pair of points, which is
+    # O(m**4)
+
+
+@pytest.mark.parametrize("lon", np.arange(0, 360, 30))
+@pytest.mark.parametrize("lat", np.linspace(-90, 90, 7))
+@pytest.mark.parametrize("ntrunc", NTRUNC)
+def test_specintrp(lon, lat, ntrunc):
+    ncoeffs = (ntrunc + 1) * (ntrunc + 2) // 2
+    test_coeffs = np.ones(ncoeffs, dtype="c8")
+    legfuncs = spharm.legendre(lat, ntrunc)
+    interpolated = spharm.specintrp(lon, test_coeffs, legfuncs)
+    assert np.isfinite(interpolated)

--- a/tests/test_spharm.py
+++ b/tests/test_spharm.py
@@ -7,6 +7,7 @@ crashes).  Occasionally there are checks of other properties.
 There are a few checks that we can round-trip information.
 
 """
+
 import itertools
 
 import numpy as np
@@ -16,8 +17,8 @@ import spharm
 
 # T799 transforms result in nans
 # T382 on a 512x1024 grid seems to work fine
-NTRUNC = [21, 42, 63, 85, 106, 159]#, 255, 382]
-NLATS = [32, 64, 96, 128, 160, 256]#, 384, 512]
+NTRUNC = [21, 42, 63]  # , 85, 106, 159]#, 255, 382]
+NLATS = [32, 64, 96]  # , 128, 160, 256]#, 384, 512]
 
 
 @pytest.fixture(


### PR DESCRIPTION
- `tests/test_spharm.py` checks simple things, mostly output shape or that arrays of ones round-trip
- `tests/test_array_api.py` checks whether the package breaks on non-NumPy arrays.  This would be more useful if `numpy.f2py` used `empty_like` to generate output arrays of the same type as the input arrays; I could probably also test this with dask arrays.  This is not a test of core package functionality.
- `tests/test_hypothesis.py` checks whether certain functions can round-trip their input, trying to find inputs it can't

It should be possible to install the packages needed for the tests with `pip install /path/to/pyspharm[tests]`, and to run them with `pytest tests`.

Part of the motivation for adding these was a desire to modernize the Fortran code (my compiler dislikes three-way if and shared `do`-termination labels); I wanted something in place to tell me if I mucked things up before I started.