### PR TITLE
DEV: Tell git status to ignore more generated files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,24 @@
 # Built object files
 src/*.o
+*.o
 
 # Python build system intermediate files
 /build/
 /pyspharm.dist-info/
 /pyspharm.egg-info/
+MANIFEST
+/.mesonpy-*/
+/.hypothesis/
+/.asv/
 
 # Source and binary distributions from setuptools
 /dist/
+
+# Byte-compiled python files
+__pycache__
+*.pyc
+*.pyo
+
+# Other generated files
+/.tox/
+/*.log


### PR DESCRIPTION
There's a few git commands that will ignore files matching patterns listed in a file conveniently named `.gitignore`.  I use `git status` to check whether I've forgotten to save my work, and like the output to be reasonably short.