### PR TITLE
BLD: Add more metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,20 @@ authors = [
 readme = "README.md"
 license = { file = "LICENSE.spherepack" }
 classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Fortran",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering :: Atmospheric Science"
 ]
 dependencies = [ "numpy" ]
+keywords = ["spherical harmonic transform"]
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "http://github.com/jswhit/pyspharm"


### PR DESCRIPTION
The important one is `requires-python`, so pip knows to get the `numpy.distutils` version if it can't install meson-python due to too old a version of python.